### PR TITLE
Command section fixes

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -15,10 +15,8 @@ $this->providePermission(Permission::API, $this->translate('Allow to access the 
 $this->providePermission(Permission::AUDIT, $this->translate('Allow to access the full audit log'));
 $this->providePermission(Permission::CLONE, $this->translate('Allow to clone objects'));
 $this->providePermission(Permission::BASKETS, $this->translate('Allow to access the basket dashboard'));
-$this->providePermission(Permission::COMMANDS, $this->translate('Allow to access the commands section'));
+$this->providePermission(Permission::COMMANDS, $this->translate('Allow to access the commands section including check commands and external commands'));
 $this->providePermission(Permission::COMMAND_CREATE, $this->translate('Allow to create the commands'));
-$this->providePermission(Permission::COMMAND_CHECK, $this->translate('Allow to access the check commands section'));
-$this->providePermission(Permission::COMMAND_EXTERNAL, $this->translate('Allow to access the external commands section'));
 $this->providePermission(Permission::COMMAND_TEMPLATES, $this->translate('Allow to access the command templates section'));
 $this->providePermission(Permission::DEPLOY, $this->translate('Allow to deploy configuration'));
 $this->providePermission(Permission::INSPECT, $this->translate(

--- a/library/Director/Auth/Permission.php
+++ b/library/Director/Auth/Permission.php
@@ -12,8 +12,6 @@ class Permission
     public const BASKETS = 'director/baskets';
     public const COMMANDS = 'director/commands';
     public const COMMAND_CREATE = 'director/command_create';
-    public const COMMAND_CHECK = 'director/command_check';
-    public const COMMAND_EXTERNAL = 'director/command_external';
     public const COMMAND_TEMPLATES = 'director/command_templates';
     public const DEPLOY = 'director/deploy';
     public const DEPLOYMENTS = 'director/deployments'; // internal, assign ALL_PERMISSONS

--- a/library/Director/Dashboard/Dashlet/CheckCommandsDashlet.php
+++ b/library/Director/Dashboard/Dashlet/CheckCommandsDashlet.php
@@ -23,7 +23,7 @@ class CheckCommandsDashlet extends Dashlet
 
     public function listRequiredPermissions()
     {
-        return [Permission::COMMAND_CHECK];
+        return [Permission::COMMANDS];
     }
 
     public function getUrl()

--- a/library/Director/Dashboard/Dashlet/CommandObjectDashlet.php
+++ b/library/Director/Dashboard/Dashlet/CommandObjectDashlet.php
@@ -2,7 +2,9 @@
 
 namespace Icinga\Module\Director\Dashboard\Dashlet;
 
+use Icinga\Module\Director\Acl;
 use Icinga\Module\Director\Auth\Permission;
+use RuntimeException;
 
 class CommandObjectDashlet extends Dashlet
 {
@@ -22,6 +24,13 @@ class CommandObjectDashlet extends Dashlet
 
     public function listRequiredPermissions()
     {
-        return [Permission::COMMANDS];
+        throw new RuntimeException('This method should not be accessed, isAllowed() has been implemented');
+    }
+
+    public function isAllowed()
+    {
+        $acl = Acl::instance();
+        return $acl->hasPermission(Permission::COMMANDS)
+            || $acl->hasPermission(Permission::COMMAND_TEMPLATES);
     }
 }

--- a/library/Director/Dashboard/Dashlet/ExternalCheckCommandsDashlet.php
+++ b/library/Director/Dashboard/Dashlet/ExternalCheckCommandsDashlet.php
@@ -23,7 +23,7 @@ class ExternalCheckCommandsDashlet extends CheckCommandsDashlet
 
     public function listRequiredPermissions()
     {
-        return [Permission::COMMAND_EXTERNAL];
+        return [Permission::COMMANDS];
     }
 
     public function getUrl()

--- a/library/Director/Web/Controller/ObjectsController.php
+++ b/library/Director/Web/Controller/ObjectsController.php
@@ -41,7 +41,7 @@ abstract class ObjectsController extends ActionController
     protected function checkDirectorPermissions()
     {
         if ($this->getRequest()->getActionName() !== 'sets') {
-            $this->assertPermission('director/' . $this->getPluralBaseType());
+            $this->hasPermission('director/' . $this->getPluralBaseType());
         }
     }
 


### PR DESCRIPTION
fixed variable permissions so director/command_templates does not depend on director/commands and can be given seperately (also other way around), so now there wont be any error message that access to director/commands is missing

Adjusted permissions for the comamnd dashlets and applied a similar permission check like in the serviceobjectdashlet.

changed the checkdirectorpermission function in Objectscontroller.php from assertPermission() to has Permission()